### PR TITLE
Clarify roles in assessing IPR status of contributions

### DIFF
--- a/webrtc-charter.html
+++ b/webrtc-charter.html
@@ -397,7 +397,7 @@ will be developed in coordination with the <a href="http://www.w3.org/WAI/PF/">A
       <p>As explained in the Process Document (<a href="/Consortium/Process/policies#Consensus">section 3.3</a>), this group will seek to make decisions when there is consensus. When the Chair puts a question and observes dissent, after due consideration of different opinions, the Chair should record a decision (possibly after a formal vote) and any objections, and move on.</p>
       <p>After mailing list and other informal discussion, substantive change proposals should be submitted as GitHub pull requests.  These can come from the editors or from WG members.</p>
       <p>Chairs are responsible for determining whether or not there is WG consensus for the changes contained in a pull request.
-      <p>Editors are responsible for “curating” the pull requests to reject frivolous ones and substantive ones that are not from WG members (in order to ensure compliance with the IPR policies).</p>
+      <p>Editors are responsible for “curating” the pull requests to reject frivolous ones and substantive ones that the Chairs have determined do not comply with the IPR policies.</p>
       <p>In cases where the editors make substantive changes without WG consensus, those changes must be labelled as provisional. The chairs are responsible for resolving the status of such changes.
     </div>
 


### PR DESCRIPTION
Chairs are responsible for assessing whether a substantive contribution
match the IPR requirements.
