### PR TITLE
Revise IETF interaction language

### DIFF
--- a/webrtc-charter.html
+++ b/webrtc-charter.html
@@ -239,7 +239,7 @@
             <dd>An extension to the WebRTC 1.0 API to enable experimentation with QoS marking.</dd>
           </dl>
 
-<p>This work will be done in collaboration with the IETF. The W3C will define APIs to ensure that application developers can control the components or the architecture for selection and profiling of the wire protocols that will be produced by the IETF Real-Time Communication in WEB-browsers (RTCWeb) Working Group. While the specified API Functions will not constrain implementations into supporting a specific profile, they will be compatible with the Profile that will be specified by the RTCWeb Working Group.</p>
+<p>This work will be done in collaboration with the IETF. The W3C will define APIs to ensure that application developers can control the components or the architecture for selection and profiling of the wire protocols that have been produced by the IETF Real-Time Communication in WEB-browsers (RTCWeb) Working Group. While the specified API Functions will not constrain implementations into supporting a specific profile, they will be compatible with the Profile that is specified by the RTCWeb Working Group.</p>
 
 <p>As the name indicates, WebRTC 1.0: Real-time Communication Between Browsers is a first version of APIs for real-time communication, sometimes referred to as the PeerConnection API. The activities in the ORTC (Object Real-time Communications) Community Group indicate that there is interest in additional APIs to provide more direct control over WebRTC than what the PeerConnection API offers.</p>
 
@@ -258,7 +258,7 @@
 
 <p>The specified API Functions and the requirements on their implementation must offer functionality that ensures that users' expectations of privacy and control over their devices are met - this includes, but is not limited to, ensuring that users can control what local  devices an application can access for capturing media, and are able to at any time revoke that access.</p>
 
-<p>Similarly, all the deliverables must address issues of security. The security and privacy goals and requirements will be developed in coordination with the IETF RTCWeb Working Group.</p>
+<p>Similarly, all the deliverables must address issues of security. The security and privacy goals and requirements will be harmonized with those developed by the IETF RTCWeb Working Group.</p>
 
 <p>Similarly, all deliverables must address issues of accessibility
 including relevant requirements listed in the <a href="https://w3c.github.io/apa/media-accessibility-reqs/">Media User Accessibility
@@ -325,8 +325,8 @@ will be developed in coordination with the <a href="https://www.w3.org/WAI/APA/"
 
           <h3 id="external-coordination">External Organizations</h3>
           <dl>
-	    <dt><a href="https://datatracker.ietf.org/wg/rtcweb/">IETF Real-Time Communication in WEB-browsers group</a> (RTCWeb)</dt>
-	    <dd>The RTC APIs developed by this group will build upon the protocols and formats developed in the IETF RTCWeb Working Group, which will in general handle dependencies to other IETF Working Groups.</dd>
+	    <dt><a href="https://datatracker.ietf.org/wg/#art">IETF Applications and Real-Time Area</a> (ART)</dt>
+	    <dd>The RTC APIs developed by this group will build upon the protocols and formats developed in the IETF RTCWeb Working Group. Subsequent to the termination of that WG, this WG will liaise with other groups of the ART area and elsewhere in the IETF as appropriate; of particular interest are the MMUSIC, AVTEXT and QUIC working groups.</dd>
           </dl>
 
 


### PR DESCRIPTION
Admit that the RTCWEB WG is largely done, and liaise
with the ART area instead (and possibly others - QUIC
is in Transport).

Fixes #18