### PR TITLE
Move QUIC from explicit work item to possibility

### DIFF
--- a/webrtc-charter.html
+++ b/webrtc-charter.html
@@ -220,7 +220,8 @@
             <dd>API functions that allow to query for the components present in an implementation, instantiate them, and connect them to media streams.</dd>
             <dt>Data Transfer Functions</dt>
             <dd>API functions to provide interfaces that enable the transfer of data between peers, 
-            Included in this category are API functions for message-based as well as stream-based communications.</dd>
+              Included in this category are API functions for message-based as well as stream-based communications.
+              <br>The WG will consider any necessary API changes or extensions to enable use of more than one data transfer protocol to support the data transfer functions.</dd>
             <dt>P2P Connection Functions</dt>
             <dd>API functions to provide interfaces that enable the conveyance of parameters necessary to establish peer to peer connections, based on the protocols selected by the IETF RTCWeb Working Group. Included in this category are also API functions to allow identification of the peer.</dd>
           </dl>
@@ -248,8 +249,6 @@
             <dd>JavaScript APIs that let a Web application manage how audio is rendered on the user audio output devices</dd>
             <dt><a href="https://w3c.github.io/mediacapture-screen-share/">Screen Capture</a></dt>
             <dd>An extension to the Media Capture and Streams API to use a user's display, or parts thereof, as the source of a MediaStream.</dd>
-	    <dt><a href="https://w3c.github.io/webrtc-quic/">QUIC in WebRTC</a></dt>
-            <dd>An extension to the WebRTC 1.0 API to enable use of peer-to-peer QUIC streams for data exchange.</dd>
             <dt><a href="https://github.com/w3c/webrtc-ice/">IceTransport extensions</a></dt>
             <dd>An extension to the WebRTC 1.0 API to enable construction of RTCIceTransport objects.</dd>
             <dt><a href="https://w3c.github.io/webrtc-dscp-exp/">DSCP Control API</a></dt>


### PR DESCRIPTION
The discussion on the WG indicated that not everyone agreed
that QUIC is the obvious candidate for "the next protocol
to incorporate".

This CL moves the work on additional API for other data
protocols from an explicit QUIC work item to being part of
the "data transfer" functions bullet.

Fixes #27 (maybe)