### PR TITLE
Feature removal policy

### DIFF
--- a/webrtc-charter.html
+++ b/webrtc-charter.html
@@ -301,6 +301,9 @@ ended on 05 July 2013<br>Produced under <a href="https://www.w3.org/2011/04/webr
 
 <p>This work will be done in collaboration with the IETF. The W3C will define APIs to ensure that application developers can control the components or the architecture for selection and profiling of the wire protocols that have been produced by the IETF Real-Time Communication in WEB-browsers (RTCWeb) Working Group. While the specified API Functions will not constrain implementations into supporting a specific profile, they will be compatible with the Profile that is specified by the RTCWeb Working Group.</p>
 
+<p>The highest priority of the group in this charter period will be to get the core recommendations progressed towards Recommendation status. To that end, features that are not demonstrated to be implemented by at least two browsers withih the timeframes indicated will be removed from the specifications. Depending on their nature, they may be republished as extension specification, or simply dropped.</p>
+<p>If such removal would compromise the ability to deliver on the requirements specified in this charter, the group may choose to recharter in order to revise its requirements.</p>
+
 <p>As the name indicates, WebRTC 1.0: Real-time Communication Between Browsers is a first version of APIs for real-time communication, sometimes referred to as the PeerConnection API. The activities in the ORTC (Object Real-time Communications) Community Group indicate that there is interest in additional APIs to provide more direct control over WebRTC than what the PeerConnection API offers.</p>
 
 <p>In recognition of this interest, the Working Group intends to start work on a new set of object-oriented APIs for real-time communication.</p>


### PR DESCRIPTION
Fixes #45. I added words to indicate that we'll not make removals that make the specification useless, but otherwise, we go for hard removal.
