### PR TITLE
add missing /ul, more accurate Changes summary

### DIFF
--- a/webrtc-charter.html
+++ b/webrtc-charter.html
@@ -462,7 +462,8 @@ interoperability can be verified by passing open test suites.</p>
                                                                     </li>
                                 <li>Produced under Working Group Charter:
                                                                             <a href="https://www.w3.org/2018/07/webrtc-charter.html">https://www.w3.org/2018/07/webrtc-charter.html</a>                                                                    </li>
-                                            <li><a href="https://w3c.github.io/mediacapture-handle/actions/">The Capture-Handle Actions Mechanism</a>
+			    </ul>
+<li><a href="https://w3c.github.io/mediacapture-handle/actions/">The Capture-Handle Actions Mechanism</a>
   <ul>
     <li>Draft state: Editor's draft</li>
   </ul>
@@ -801,7 +802,12 @@ will be developed in coordination with the <a href="https://www.w3.org/groups/wg
                   <i class=todo>@@@ 2026</i>
                 </td>
                 <td>
-                   This charter reflects the updated list of deliverables the WebRTC Working Group is developing
+                   <ul>
+			<li>Updated <a href="#success-criteria">Success Criteria section</a> with more modern interoperability and testing requirements</li>
+			<li>Updated <a href="#coordination">Coordination section</a> with more horizontal review details</li>
+			<li>Re-ordered list of deliverables</li>
+			<li>Added one new deliverable: WebRTC RTP Transport</li>
+		   </ul>
                 </td>
               </tr>
             </tbody>


### PR DESCRIPTION
markup fix: add a missing `</ul>` tag that was errantly causing a few deliverables to nest inside of another deliverable.

editorial: update copy/paste of prior "Changes" summary to a summary of the actual changes made in this charter update.